### PR TITLE
Improve Proto Documentation Build and HTML Comment Rendering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,33 @@ help: ## Print usage info about help targets
 makefile_chapters: ## Shows all sections of Makefile
 	@echo `cat Makefile| grep "########################################################" -A 1 | grep -v "########################################################"`
 
+build_docs: ## Build documentation locally using the same Docker image as CI/CD
+	@echo "Building documentation using ondewo-protoc-gen-doc-action..."
+	@if [ ! -d ".tmp-protoc-gen-doc-action" ]; then \
+		echo "Cloning ondewo-protoc-gen-doc-action..."; \
+		git clone --depth 1 https://github.com/ondewo/ondewo-protoc-gen-doc-action.git .tmp-protoc-gen-doc-action; \
+	fi
+	@echo "Building Docker image with ONDEWO templates..."
+	@docker build -t ondewo-protoc-gen-doc:local .tmp-protoc-gen-doc-action
+	@echo "Generating documentation..."
+	@mkdir -p googleapis
+	@docker run --rm \
+		--user "$(shell id -u):$(shell id -g)" \
+		-v "$(shell pwd):/workspace" \
+		-w /workspace \
+		ondewo-protoc-gen-doc:local \
+		html,md index
+	@rmdir googleapis 2>/dev/null || true
+	@echo "✓ Documentation generated in docs/ directory"
+	@echo "  Open docs/index.html in your browser to view"
+
+clean_docs_builder: ## Remove the cloned protoc-gen-doc-action repo and Docker image
+	@echo "Cleaning up documentation builder..."
+	@rm -rf .tmp-protoc-gen-doc-action
+	@docker rmi ondewo-protoc-gen-doc:local 2>/dev/null || true
+	@echo "✓ Cleanup complete"
+
+
 TEST:
 	@echo "----------------------------------------------\nGITHUB_GH_TOKEN\n----------------------------------------------\n${GITHUB_GH_TOKEN}\n"
 	@echo "----------------------------------------------\nCURRENT_RELEASE_NOTES\n----------------------------------------------\n${CURRENT_RELEASE_NOTES}\n"

--- a/Makefile
+++ b/Makefile
@@ -88,14 +88,12 @@ build_docs: ## Build documentation locally using the same Docker image as CI/CD
 	@echo "Building Docker image with ONDEWO templates..."
 	@docker build -t ondewo-protoc-gen-doc:local .tmp-protoc-gen-doc-action
 	@echo "Generating documentation..."
-	@mkdir -p googleapis
 	@docker run --rm \
 		--user "$(shell id -u):$(shell id -g)" \
 		-v "$(shell pwd):/workspace" \
 		-w /workspace \
 		ondewo-protoc-gen-doc:local \
 		html,md index
-	@rmdir googleapis 2>/dev/null || true
 	@echo "✓ Documentation generated in docs/ directory"
 	@echo "  Open docs/index.html in your browser to view"
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -283,7 +283,7 @@
         
       
         <h3 id="ondewo.sip.SipRegisterAccountRequest" class="title-badge message">SipRegisterAccountRequest</h3>
-        <p></p>
+        <p><p>Request for registering a SIP account at a SIP server</p></p>
 
         
           <table class="field-table">
@@ -412,7 +412,7 @@ Also a non-default SIP port can be specified via <code>sip-user-1@mydomain.com:5
                   <td>auto_answer_interval</td>
                   <td><a href="#int32">int32</a></td>
                   <td></td>
-                  <td><p>answer interval </p></td>
+                  <td><p>Auto-answer interval in seconds. The call will be automatically answered after this interval </p></td>
                 </tr>
               
             </tbody>
@@ -423,7 +423,7 @@ Also a non-default SIP port can be specified via <code>sip-user-1@mydomain.com:5
         
       
         <h3 id="ondewo.sip.SipStatus" class="title-badge message">SipStatus</h3>
-        <p></p>
+        <p><p>Status information for a SIP account, session, or call</p></p>
 
         
           <table class="field-table">

--- a/docs/index.html
+++ b/docs/index.html
@@ -154,7 +154,7 @@
       
         
         <h3 id="ondewo.sip.Sip" class="title-badge service">Sip</h3>
-        <p>ONDEWO-SIP API available at <a href="https://github.com/ondewo/ondewo-sip-api>">GitHub</a></p><p>SIP LifeCycle is explained at <a href="https://thanhloi2603.wordpress.com/2017/06/10/sip-lifecycle-overview/">here</a></p>
+        <p><p>ONDEWO-SIP API available at <a href="https://github.com/ondewo/ondewo-sip-api">GitHub</a></p></p><p><p>SIP LifeCycle is explained at <a href="https://thanhloi2603.wordpress.com/2017/06/10/sip-lifecycle-overview/">here</a></p></p>
 
         
         <div id="ondewo.sip.Sip-methods" class="service-methods">Service Methods</div>
@@ -163,68 +163,67 @@
 
           <pre>rpc SipStartSession (<a href="#ondewo.sip.SipStartSessionRequest">SipStartSessionRequest</a>) returns (<a href="#ondewo.sip.SipStatus">SipStatus)</a></pre>
 
-          Starts a new SIP session for an account registered at a SIP server. <code>RegisterAccount</code> need to be called before.
+          <p>Starts a new SIP session for an account registered at a SIP server. <code>RegisterAccount</code> need to be called before.</p>
         
           <h4 id="ondewo.sip.Sip.SipEndSession" class="title-badge method">SipEndSession</h4>
 
           <pre>rpc SipEndSession (<a href="#google.protobuf.Empty">.google.protobuf.Empty</a>) returns (<a href="#ondewo.sip.SipStatus">SipStatus)</a></pre>
 
-          Ends a SIP session for an account registered at a SIP server
+          <p>Ends a SIP session for an account registered at a SIP server</p>
         
           <h4 id="ondewo.sip.Sip.SipStartCall" class="title-badge method">SipStartCall</h4>
 
           <pre>rpc SipStartCall (<a href="#ondewo.sip.SipStartCallRequest">SipStartCallRequest</a>) returns (<a href="#ondewo.sip.SipStatus">SipStatus)</a></pre>
 
-          Starts a call in an active SIP session for an account registered at a SIP server
+          <p>Starts a call in an active SIP session for an account registered at a SIP server</p>
         
           <h4 id="ondewo.sip.Sip.SipEndCall" class="title-badge method">SipEndCall</h4>
 
           <pre>rpc SipEndCall (<a href="#ondewo.sip.SipEndCallRequest">SipEndCallRequest</a>) returns (<a href="#ondewo.sip.SipStatus">SipStatus)</a></pre>
 
-          Ends a call in an active SIP session for an account registered at a SIP server
+          <p>Ends a call in an active SIP session for an account registered at a SIP server</p>
         
           <h4 id="ondewo.sip.Sip.SipTransferCall" class="title-badge method">SipTransferCall</h4>
 
           <pre>rpc SipTransferCall (<a href="#ondewo.sip.SipTransferCallRequest">SipTransferCallRequest</a>) returns (<a href="#ondewo.sip.SipStatus">SipStatus)</a></pre>
 
-          Transfers a call in an active SIP session for an account registered at a SIP server to
-another SIP account or phone number specified by <code>transfer_id</code>
+          <p>Transfers a call in an active SIP session for an account registered at a SIP server to another SIP account or phone number specified by <code>transfer_id</code></p>
         
           <h4 id="ondewo.sip.Sip.SipRegisterAccount" class="title-badge method">SipRegisterAccount</h4>
 
           <pre>rpc SipRegisterAccount (<a href="#ondewo.sip.SipRegisterAccountRequest">SipRegisterAccountRequest</a>) returns (<a href="#ondewo.sip.SipStatus">SipStatus)</a></pre>
 
-          Registers s SIP account at a SIP server
+          <p>Registers s SIP account at a SIP server</p>
         
           <h4 id="ondewo.sip.Sip.SipGetSipStatus" class="title-badge method">SipGetSipStatus</h4>
 
           <pre>rpc SipGetSipStatus (<a href="#google.protobuf.Empty">.google.protobuf.Empty</a>) returns (<a href="#ondewo.sip.SipStatus">SipStatus)</a></pre>
 
-          Gets the current SIP status
+          <p>Gets the current SIP status</p>
         
           <h4 id="ondewo.sip.Sip.SipGetSipStatusHistory" class="title-badge method">SipGetSipStatusHistory</h4>
 
           <pre>rpc SipGetSipStatusHistory (<a href="#google.protobuf.Empty">.google.protobuf.Empty</a>) returns (<a href="#ondewo.sip.SipStatusHistoryResponse">SipStatusHistoryResponse)</a></pre>
 
-          Gets the history of SIP status
+          <p>Gets the history of SIP status</p>
         
           <h4 id="ondewo.sip.Sip.SipPlayWavFiles" class="title-badge method">SipPlayWavFiles</h4>
 
           <pre>rpc SipPlayWavFiles (<a href="#ondewo.sip.SipPlayWavFilesRequest">SipPlayWavFilesRequest</a>) returns (<a href="#ondewo.sip.SipStatus">SipStatus)</a></pre>
 
-          Plays wav files during an ongoing call of an active SIP session
+          <p>Plays wav files during an ongoing call of an active SIP session</p>
         
           <h4 id="ondewo.sip.Sip.SipMute" class="title-badge method">SipMute</h4>
 
           <pre>rpc SipMute (<a href="#google.protobuf.Empty">.google.protobuf.Empty</a>) returns (<a href="#ondewo.sip.SipStatus">SipStatus)</a></pre>
 
-          Mutes the microphone in an ongoing call of an active SIP session
+          <p>Mutes the microphone in an ongoing call of an active SIP session</p>
         
           <h4 id="ondewo.sip.Sip.SipUnMute" class="title-badge method">SipUnMute</h4>
 
           <pre>rpc SipUnMute (<a href="#google.protobuf.Empty">.google.protobuf.Empty</a>) returns (<a href="#ondewo.sip.SipStatus">SipStatus)</a></pre>
 
-          Un-mutes the microphone in an ongoing call of an active SIP session
+          <p>Un-mutes the microphone in an ongoing call of an active SIP session</p>
         
 
         
@@ -236,7 +235,7 @@ another SIP account or phone number specified by <code>transfer_id</code>
       <div id="ondewo/sip/sip.proto-messages" class="object-category">Messages</div>
       
         <h3 id="ondewo.sip.SipEndCallRequest" class="title-badge message">SipEndCallRequest</h3>
-        <p>Ends an ongoing call of the active SIP session of the active SIP account</p>
+        <p><p>Ends an ongoing call of the active SIP session of the active SIP account</p></p>
 
         
           <table class="field-table">
@@ -260,7 +259,7 @@ another SIP account or phone number specified by <code>transfer_id</code>
         
       
         <h3 id="ondewo.sip.SipPlayWavFilesRequest" class="title-badge message">SipPlayWavFilesRequest</h3>
-        <p>Plays a list of wav files</p>
+        <p><p>Plays a list of wav files</p></p>
 
         
           <table class="field-table">
@@ -297,10 +296,8 @@ another SIP account or phone number specified by <code>transfer_id</code>
                   <td>account_name</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>Account name of the sip user. Usually something like <code>sip-user-1@mydomain.com</code> or
-<code>sip-user-1@192.168.123.123</code> which uses the default SIP port <code>5060</code>.
-Also a non-default SIP port can be specified via <code>sip-user-1@mydomain.com:5099</code> to connect
-to a SIP server running on port <code>5099</code> </p></td>
+                  <td><p>Account name of the sip user. Usually something like <code>sip-user-1@mydomain.com</code> or <code>sip-user-1@192.168.123.123</code> which uses the default SIP port <code>5060</code>.
+Also a non-default SIP port can be specified via <code>sip-user-1@mydomain.com:5099</code> to connect to a SIP server running on port <code>5099</code> </p></td>
                 </tr>
               
                 <tr>
@@ -332,7 +329,7 @@ to a SIP server running on port <code>5099</code> </p></td>
         
       
         <h3 id="ondewo.sip.SipStartCallRequest" class="title-badge message">SipStartCallRequest</h3>
-        <p>Request to start the call with the active SIP session of the active SIP account</p>
+        <p><p>Request to start the call with the active SIP session of the active SIP account</p></p>
 
         
           <table class="field-table">
@@ -394,7 +391,7 @@ to a SIP server running on port <code>5099</code> </p></td>
         
       
         <h3 id="ondewo.sip.SipStartSessionRequest" class="title-badge message">SipStartSessionRequest</h3>
-        <p>Request for starting a new SIP session for a specified account</p>
+        <p><p>Request for starting a new SIP session for a specified account</p></p>
 
         
           <table class="field-table">
@@ -407,10 +404,8 @@ to a SIP server running on port <code>5099</code> </p></td>
                   <td>account_name</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>Account name of the sip user. Usually something like <code>sip-user-1@mydomain.com</code> or
-<code>sip-user-1@192.168.123.123</code> which uses the default SIP port <code>5060</code>.
-Also a non-default SIP port can be specified via <code>sip-user-1@mydomain.com:5099</code> to connect
-to a SIP server running on port <code>5099</code> </p></td>
+                  <td><p>Account name of the sip user. Usually something like <code>sip-user-1@mydomain.com</code> or <code>sip-user-1@192.168.123.123</code> which uses the default SIP port <code>5060</code>.
+Also a non-default SIP port can be specified via <code>sip-user-1@mydomain.com:5099</code> to connect to a SIP server running on port <code>5099</code> </p></td>
                 </tr>
               
                 <tr>
@@ -441,10 +436,8 @@ to a SIP server running on port <code>5099</code> </p></td>
                   <td>account_name</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>Account name of the sip user. Usually something like <code>sip-user-1@mydomain.com</code> or
-<code>sip-user-1@192.168.123.123</code> which uses the default SIP port <code>5060</code>.
-Also a non-default SIP port can be specified via <code>sip-user-1@mydomain.com:5099</code> to connect
-to a SIP server running on port <code>5099</code> </p></td>
+                  <td><p>Account name of the sip user. Usually something like <code>sip-user-1@mydomain.com</code> or <code>sip-user-1@192.168.123.123</code> which uses the default SIP port <code>5060</code>.
+Also a non-default SIP port can be specified via <code>sip-user-1@mydomain.com:5099</code> to connect to a SIP server running on port <code>5099</code> </p></td>
                 </tr>
               
                 <tr>
@@ -549,7 +542,7 @@ to a SIP server running on port <code>5099</code> </p></td>
         
       
         <h3 id="ondewo.sip.SipStatusHistoryResponse" class="title-badge message">SipStatusHistoryResponse</h3>
-        <p>History of SIP status</p>
+        <p><p>History of SIP status</p></p>
 
         
           <table class="field-table">
@@ -573,7 +566,7 @@ to a SIP server running on port <code>5099</code> </p></td>
         
       
         <h3 id="ondewo.sip.SipTransferCallRequest" class="title-badge message">SipTransferCallRequest</h3>
-        <p>Request for transferring a call with or without headers</p>
+        <p><p>Request for transferring a call with or without headers</p></p>
 
         
           <table class="field-table">

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@
 <a name="ondewo.sip.SipEndCallRequest"></a>
 
 ### SipEndCallRequest
-Ends an ongoing call of the active SIP session of the active SIP account
+<p>Ends an ongoing call of the active SIP session of the active SIP account</p>
 
 
 | Field | Type | Label | Description |
@@ -49,7 +49,7 @@ Ends an ongoing call of the active SIP session of the active SIP account
 <a name="ondewo.sip.SipPlayWavFilesRequest"></a>
 
 ### SipPlayWavFilesRequest
-Plays a list of wav files
+<p>Plays a list of wav files</p>
 
 
 | Field | Type | Label | Description |
@@ -82,7 +82,7 @@ Plays a list of wav files
 <a name="ondewo.sip.SipStartCallRequest"></a>
 
 ### SipStartCallRequest
-Request to start the call with the active SIP session of the active SIP account
+<p>Request to start the call with the active SIP session of the active SIP account</p>
 
 
 | Field | Type | Label | Description |
@@ -114,7 +114,7 @@ Request to start the call with the active SIP session of the active SIP account
 <a name="ondewo.sip.SipStartSessionRequest"></a>
 
 ### SipStartSessionRequest
-Request for starting a new SIP session for a specified account
+<p>Request for starting a new SIP session for a specified account</p>
 
 
 | Field | Type | Label | Description |
@@ -170,7 +170,7 @@ Request for starting a new SIP session for a specified account
 <a name="ondewo.sip.SipStatusHistoryResponse"></a>
 
 ### SipStatusHistoryResponse
-History of SIP status
+<p>History of SIP status</p>
 
 
 | Field | Type | Label | Description |
@@ -185,7 +185,7 @@ History of SIP status
 <a name="ondewo.sip.SipTransferCallRequest"></a>
 
 ### SipTransferCallRequest
-Request for transferring a call with or without headers
+<p>Request for transferring a call with or without headers</p>
 
 
 | Field | Type | Label | Description |
@@ -255,23 +255,23 @@ Types of status
 <a name="ondewo.sip.Sip"></a>
 
 ### Sip
-ONDEWO-SIP API available at <a href="https://github.com/ondewo/ondewo-sip-api>">GitHub</a>
+<p>ONDEWO-SIP API available at <a href="https://github.com/ondewo/ondewo-sip-api">GitHub</a></p>
 
-SIP LifeCycle is explained at <a href="https://thanhloi2603.wordpress.com/2017/06/10/sip-lifecycle-overview/">here</a>
+<p>SIP LifeCycle is explained at <a href="https://thanhloi2603.wordpress.com/2017/06/10/sip-lifecycle-overview/">here</a></p>
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| SipStartSession | [SipStartSessionRequest](#ondewo.sip.SipStartSessionRequest) | [SipStatus](#ondewo.sip.SipStatus) | Starts a new SIP session for an account registered at a SIP server. <code>RegisterAccount</code> need to be called before. |
-| SipEndSession | [.google.protobuf.Empty](#google.protobuf.Empty) | [SipStatus](#ondewo.sip.SipStatus) | Ends a SIP session for an account registered at a SIP server |
-| SipStartCall | [SipStartCallRequest](#ondewo.sip.SipStartCallRequest) | [SipStatus](#ondewo.sip.SipStatus) | Starts a call in an active SIP session for an account registered at a SIP server |
-| SipEndCall | [SipEndCallRequest](#ondewo.sip.SipEndCallRequest) | [SipStatus](#ondewo.sip.SipStatus) | Ends a call in an active SIP session for an account registered at a SIP server |
-| SipTransferCall | [SipTransferCallRequest](#ondewo.sip.SipTransferCallRequest) | [SipStatus](#ondewo.sip.SipStatus) | Transfers a call in an active SIP session for an account registered at a SIP server to another SIP account or phone number specified by <code>transfer_id</code> |
-| SipRegisterAccount | [SipRegisterAccountRequest](#ondewo.sip.SipRegisterAccountRequest) | [SipStatus](#ondewo.sip.SipStatus) | Registers s SIP account at a SIP server |
-| SipGetSipStatus | [.google.protobuf.Empty](#google.protobuf.Empty) | [SipStatus](#ondewo.sip.SipStatus) | Gets the current SIP status |
-| SipGetSipStatusHistory | [.google.protobuf.Empty](#google.protobuf.Empty) | [SipStatusHistoryResponse](#ondewo.sip.SipStatusHistoryResponse) | Gets the history of SIP status |
-| SipPlayWavFiles | [SipPlayWavFilesRequest](#ondewo.sip.SipPlayWavFilesRequest) | [SipStatus](#ondewo.sip.SipStatus) | Plays wav files during an ongoing call of an active SIP session |
-| SipMute | [.google.protobuf.Empty](#google.protobuf.Empty) | [SipStatus](#ondewo.sip.SipStatus) | Mutes the microphone in an ongoing call of an active SIP session |
-| SipUnMute | [.google.protobuf.Empty](#google.protobuf.Empty) | [SipStatus](#ondewo.sip.SipStatus) | Un-mutes the microphone in an ongoing call of an active SIP session |
+| SipStartSession | [SipStartSessionRequest](#ondewo.sip.SipStartSessionRequest) | [SipStatus](#ondewo.sip.SipStatus) | <p>Starts a new SIP session for an account registered at a SIP server. <code>RegisterAccount</code> need to be called before.</p> |
+| SipEndSession | [.google.protobuf.Empty](#google.protobuf.Empty) | [SipStatus](#ondewo.sip.SipStatus) | <p>Ends a SIP session for an account registered at a SIP server</p> |
+| SipStartCall | [SipStartCallRequest](#ondewo.sip.SipStartCallRequest) | [SipStatus](#ondewo.sip.SipStatus) | <p>Starts a call in an active SIP session for an account registered at a SIP server</p> |
+| SipEndCall | [SipEndCallRequest](#ondewo.sip.SipEndCallRequest) | [SipStatus](#ondewo.sip.SipStatus) | <p>Ends a call in an active SIP session for an account registered at a SIP server</p> |
+| SipTransferCall | [SipTransferCallRequest](#ondewo.sip.SipTransferCallRequest) | [SipStatus](#ondewo.sip.SipStatus) | <p>Transfers a call in an active SIP session for an account registered at a SIP server to another SIP account or phone number specified by <code>transfer_id</code></p> |
+| SipRegisterAccount | [SipRegisterAccountRequest](#ondewo.sip.SipRegisterAccountRequest) | [SipStatus](#ondewo.sip.SipStatus) | <p>Registers s SIP account at a SIP server</p> |
+| SipGetSipStatus | [.google.protobuf.Empty](#google.protobuf.Empty) | [SipStatus](#ondewo.sip.SipStatus) | <p>Gets the current SIP status</p> |
+| SipGetSipStatusHistory | [.google.protobuf.Empty](#google.protobuf.Empty) | [SipStatusHistoryResponse](#ondewo.sip.SipStatusHistoryResponse) | <p>Gets the history of SIP status</p> |
+| SipPlayWavFiles | [SipPlayWavFilesRequest](#ondewo.sip.SipPlayWavFilesRequest) | [SipStatus](#ondewo.sip.SipStatus) | <p>Plays wav files during an ongoing call of an active SIP session</p> |
+| SipMute | [.google.protobuf.Empty](#google.protobuf.Empty) | [SipStatus](#ondewo.sip.SipStatus) | <p>Mutes the microphone in an ongoing call of an active SIP session</p> |
+| SipUnMute | [.google.protobuf.Empty](#google.protobuf.Empty) | [SipStatus](#ondewo.sip.SipStatus) | <p>Un-mutes the microphone in an ongoing call of an active SIP session</p> |
 
  <!-- end services -->
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@
 <a name="ondewo.sip.SipRegisterAccountRequest"></a>
 
 ### SipRegisterAccountRequest
-
+<p>Request for registering a SIP account at a SIP server</p>
 
 
 | Field | Type | Label | Description |
@@ -120,7 +120,7 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | account_name | [string](#string) |  | Account name of the sip user. Usually something like <code>sip-user-1@mydomain.com</code> or <code>sip-user-1@192.168.123.123</code> which uses the default SIP port <code>5060</code>. Also a non-default SIP port can be specified via <code>sip-user-1@mydomain.com:5099</code> to connect to a SIP server running on port <code>5099</code> |
-| auto_answer_interval | [int32](#int32) |  | answer interval |
+| auto_answer_interval | [int32](#int32) |  | Auto-answer interval in seconds. The call will be automatically answered after this interval |
 
 
 
@@ -130,7 +130,7 @@
 <a name="ondewo.sip.SipStatus"></a>
 
 ### SipStatus
-
+<p>Status information for a SIP account, session, or call</p>
 
 
 | Field | Type | Label | Description |

--- a/ondewo/sip/sip.proto
+++ b/ondewo/sip/sip.proto
@@ -18,53 +18,52 @@ package ondewo.sip;
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 
-// ONDEWO-SIP API available at <a href="https://github.com/ondewo/ondewo-sip-api>">GitHub</a>
+// <p>ONDEWO-SIP API available at <a href="https://github.com/ondewo/ondewo-sip-api">GitHub</a></p>
 service Sip {
-    // SIP LifeCycle is explained at <a href="https://thanhloi2603.wordpress.com/2017/06/10/sip-lifecycle-overview/">here</a>
+    // <p>SIP LifeCycle is explained at <a href="https://thanhloi2603.wordpress.com/2017/06/10/sip-lifecycle-overview/">here</a></p>
 
-    // Starts a new SIP session for an account registered at a SIP server. <code>RegisterAccount</code> need to be called before.
+    // <p>Starts a new SIP session for an account registered at a SIP server. <code>RegisterAccount</code> need to be called before.</p>
     rpc SipStartSession (SipStartSessionRequest) returns (SipStatus) {};
 
-    // Ends a SIP session for an account registered at a SIP server
+    // <p>Ends a SIP session for an account registered at a SIP server</p>
     rpc SipEndSession (google.protobuf.Empty) returns (SipStatus) {};
 
-    // Starts a call in an active SIP session for an account registered at a SIP server
+    // <p>Starts a call in an active SIP session for an account registered at a SIP server</p>
     rpc SipStartCall (SipStartCallRequest) returns (SipStatus) {};
 
-    // Ends a call in an active SIP session for an account registered at a SIP server
+    // <p>Ends a call in an active SIP session for an account registered at a SIP server</p>
     rpc SipEndCall (SipEndCallRequest) returns (SipStatus) {};
 
-    // Transfers a call in an active SIP session for an account registered at a SIP server to
-    // another SIP account or phone number specified by <code>transfer_id</code>
+    // <p>Transfers a call in an active SIP session for an account registered at a SIP server to another SIP account or phone number specified by <code>transfer_id</code></p>
     rpc SipTransferCall (SipTransferCallRequest) returns (SipStatus) {};
 
-    // Registers s SIP account at a SIP server
+    // <p>Registers s SIP account at a SIP server</p>
     rpc SipRegisterAccount (SipRegisterAccountRequest) returns (SipStatus) {};
 
-    // Gets the current SIP status
+    // <p>Gets the current SIP status</p>
     rpc SipGetSipStatus (google.protobuf.Empty) returns (SipStatus) {};
 
-    // Gets the history of SIP status
+    // <p>Gets the history of SIP status</p>
     rpc SipGetSipStatusHistory (google.protobuf.Empty) returns (SipStatusHistoryResponse) {};
 
-    // Plays wav files during an ongoing call of an active SIP session
+    // <p>Plays wav files during an ongoing call of an active SIP session</p>
     rpc SipPlayWavFiles (SipPlayWavFilesRequest) returns (SipStatus) {};
 
-    // Mutes the microphone in an ongoing call of an active SIP session
+    // <p>Mutes the microphone in an ongoing call of an active SIP session</p>
     rpc SipMute (google.protobuf.Empty) returns (SipStatus) {};
 
-    // Un-mutes the microphone in an ongoing call of an active SIP session
+    // <p>Un-mutes the microphone in an ongoing call of an active SIP session</p>
     rpc SipUnMute (google.protobuf.Empty) returns (SipStatus) {};
 }
 
-// Ends an ongoing call of the active SIP session of the active SIP account
+// <p>Ends an ongoing call of the active SIP session of the active SIP account</p>
 message SipEndCallRequest{
 
     // Set to <code>True</code> to forcefully hang up the call
     bool hard_hangup = 1;
 }
 
-// Request to start the call with the active SIP session of the active SIP account
+// <p>Request to start the call with the active SIP session of the active SIP account</p>
 message SipStartCallRequest{
 
     // SIP account name
@@ -75,10 +74,8 @@ message SipStartCallRequest{
 }
 
 message SipRegisterAccountRequest{
-    // Account name of the sip user. Usually something like <code>sip-user-1@mydomain.com</code> or
-    // <code>sip-user-1@192.168.123.123</code> which uses the default SIP port <code>5060</code>.
-    // Also a non-default SIP port can be specified via <code>sip-user-1@mydomain.com:5099</code> to connect
-    // to a SIP server running on port <code>5099</code>
+    // Account name of the sip user. Usually something like <code>sip-user-1@mydomain.com</code> or <code>sip-user-1@192.168.123.123</code> which uses the default SIP port <code>5060</code>.
+    // Also a non-default SIP port can be specified via <code>sip-user-1@mydomain.com:5099</code> to connect to a SIP server running on port <code>5099</code>
     string account_name = 1;
 
     // Password of the account
@@ -91,19 +88,17 @@ message SipRegisterAccountRequest{
     string outbound_proxy = 4;
 }
 
-// Request for starting a new SIP session for a specified account
+// <p>Request for starting a new SIP session for a specified account</p>
 message SipStartSessionRequest{
-    // Account name of the sip user. Usually something like <code>sip-user-1@mydomain.com</code> or
-    // <code>sip-user-1@192.168.123.123</code> which uses the default SIP port <code>5060</code>.
-    // Also a non-default SIP port can be specified via <code>sip-user-1@mydomain.com:5099</code> to connect
-    // to a SIP server running on port <code>5099</code>
+    // Account name of the sip user. Usually something like <code>sip-user-1@mydomain.com</code> or <code>sip-user-1@192.168.123.123</code> which uses the default SIP port <code>5060</code>.
+    // Also a non-default SIP port can be specified via <code>sip-user-1@mydomain.com:5099</code> to connect to a SIP server running on port <code>5099</code>
     string account_name = 1;
 
     // answer interval
     int32 auto_answer_interval = 2;
 }
 
-// Request for transferring a call with or without headers
+// <p>Request for transferring a call with or without headers</p>
 message SipTransferCallRequest{
     // The account name or phone number to transfer the call to
     string transfer_id = 1;
@@ -113,10 +108,8 @@ message SipTransferCallRequest{
 }
 
 message SipStatus{
-    // Account name of the sip user. Usually something like <code>sip-user-1@mydomain.com</code> or
-    // <code>sip-user-1@192.168.123.123</code> which uses the default SIP port <code>5060</code>.
-    // Also a non-default SIP port can be specified via <code>sip-user-1@mydomain.com:5099</code> to connect
-    // to a SIP server running on port <code>5099</code>
+    // Account name of the sip user. Usually something like <code>sip-user-1@mydomain.com</code> or <code>sip-user-1@192.168.123.123</code> which uses the default SIP port <code>5060</code>.
+    // Also a non-default SIP port can be specified via <code>sip-user-1@mydomain.com:5099</code> to connect to a SIP server running on port <code>5099</code>
     string account_name = 1;
 
     // Timestamp of the status
@@ -219,14 +212,14 @@ message SipStatus{
 
 }
 
-// History of SIP status
+// <p>History of SIP status</p>
 message SipStatusHistoryResponse{
 
     // History of SIP status
     repeated SipStatus status_history = 1;
 }
 
-// Plays a list of wav files
+// <p>Plays a list of wav files</p>
 message SipPlayWavFilesRequest{
 
     // Wav files as bytes in a list that will be played

--- a/ondewo/sip/sip.proto
+++ b/ondewo/sip/sip.proto
@@ -73,6 +73,7 @@ message SipStartCallRequest{
     map<string, string> headers = 2;
 }
 
+// <p>Request for registering a SIP account at a SIP server</p>
 message SipRegisterAccountRequest{
     // Account name of the sip user. Usually something like <code>sip-user-1@mydomain.com</code> or <code>sip-user-1@192.168.123.123</code> which uses the default SIP port <code>5060</code>.
     // Also a non-default SIP port can be specified via <code>sip-user-1@mydomain.com:5099</code> to connect to a SIP server running on port <code>5099</code>
@@ -94,7 +95,7 @@ message SipStartSessionRequest{
     // Also a non-default SIP port can be specified via <code>sip-user-1@mydomain.com:5099</code> to connect to a SIP server running on port <code>5099</code>
     string account_name = 1;
 
-    // answer interval
+    // Auto-answer interval in seconds. The call will be automatically answered after this interval
     int32 auto_answer_interval = 2;
 }
 
@@ -107,6 +108,7 @@ message SipTransferCallRequest{
     map<string, string> headers = 2;
 }
 
+// <p>Status information for a SIP account, session, or call</p>
 message SipStatus{
     // Account name of the sip user. Usually something like <code>sip-user-1@mydomain.com</code> or <code>sip-user-1@192.168.123.123</code> which uses the default SIP port <code>5060</code>.
     // Also a non-default SIP port can be specified via <code>sip-user-1@mydomain.com:5099</code> to connect to a SIP server running on port <code>5099</code>


### PR DESCRIPTION
### This PR improves documentation generation and consistency across proto files by:

Adding dedicated documentation build targets to the **Makefile** to simplify and standardise the docs build process.

Updating all comments in `sip.proto` to use valid HTML formatting instead of Markdown, ensuring correct rendering in HTML-based proto documentation tools.